### PR TITLE
Rebased on external spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install list test version
+.PHONY: all install list spec test version
 
 
 PACKAGE := $(shell grep '^PACKAGE =' setup.py | cut -d "'" -f2)
@@ -12,6 +12,9 @@ install:
 
 list:
 	@grep '^\.PHONY' Makefile | cut -d' ' -f2- | tr ' ' '\n'
+
+spec:
+	wget -O goodtables/spec.json https://raw.githubusercontent.com/frictionlessdata/data-quality-spec/master/spec.json
 
 test:
 	pylama $(PACKAGE)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Goodtables is a framework to inspect tabular data.
 ## Features
 
 - tabular data inspection and validation
-- source, structure and schema checks
+- general, structure and schema checks
 - support for different input data presets
 - parallel computation for multitable datasets
 - builtin command-line interface
@@ -64,7 +64,7 @@ print(inspector.inspect('data/invalid.csv'))
 
 ### Inspection
 
-Goodtables inspects your tabular data to find errors in source, structure and schema. As presented in an example above to inspect data:
+Goodtables inspects your tabular data to find general, structure and schema errors. As presented in an example above to inspect data:
 - `Inspector(**options)` class should be instantiated
 - `inspector.inspect(source, preset=<preset>, **options)` should be called
 - a returning value will be a report dictionary
@@ -85,7 +85,7 @@ As a result of inspection goodtables returns a report dictionary. It includes va
 
 Report errors are categorized by type:
 
-- source - data can't be loaded or parsed
+- general - data can't be loaded or parsed
 - structure - general tabular errors like duplicate headers
 - schema - error of checks against JSON Table Schema
 

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -149,7 +149,9 @@ class Inspector(object):
         except Exception as exception:
             fatal_error = True
             message = str(exception)
-            if isinstance(exception, tabulator.exceptions.SchemeError):
+            if isinstance(exception, tabulator.exceptions.SourceError):
+                code = 'source-error'
+            elif isinstance(exception, tabulator.exceptions.SchemeError):
                 code = 'scheme-error'
             elif isinstance(exception, tabulator.exceptions.FormatError):
                 code = 'format-error'

--- a/goodtables/spec.json
+++ b/goodtables/spec.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.0",
+    "version": "1.0.0-alpha1",
     "errors": [
         {
           "code": "io-error",

--- a/goodtables/spec.json
+++ b/goodtables/spec.json
@@ -4,132 +4,158 @@
         {
           "code": "io-error",
           "type": "general",
-          "context": "any"
+          "context": "any",
+          "description": ""
         },
         {
           "code": "http-error",
           "type": "general",
-          "context": "any"
+          "context": "any",
+          "description": ""
         },
         {
           "code": "datapackage-error",
           "type": "general",
-          "context": "dataset"
+          "context": "dataset",
+          "description": ""
         },
         {
           "code": "jsontableschema-error",
           "type": "general",
-          "context": "dataset"
+          "context": "dataset",
+          "description": ""
         },
         {
           "code": "source-error",
           "type": "general",
-          "context": "table"
+          "context": "table",
+          "description": ""
         },
         {
           "code": "scheme-error",
           "type": "general",
-          "context": "table"
+          "context": "table",
+          "description": ""
         },
         {
           "code": "format-error",
           "type": "general",
-          "context": "table"
+          "context": "table",
+          "description": ""
         },
         {
           "code": "encoding-error",
           "type": "general",
-          "context": "table"
+          "context": "table",
+          "description": ""
         },
         {
           "code": "blank-header",
           "type": "structure",
-          "context": "head"
+          "context": "head",
+          "description": ""
         },
         {
           "code": "duplicate-header",
           "type": "structure",
-          "context": "head"
+          "context": "head",
+          "description": ""
         },
         {
           "code": "non-matching-header",
           "type": "schema",
-          "context": "head"
+          "context": "head",
+          "description": ""
         },
         {
           "code": "extra-header",
           "type": "schema",
-          "context": "head"
+          "context": "head",
+          "description": ""
         },
         {
           "code": "missing-header",
           "type": "schema",
-          "context": "head"
+          "context": "head",
+          "description": ""
         },
         {
           "code": "blank-row",
           "type": "structure",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "duplicate-row",
           "type": "structure",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "extra-value",
           "type": "structure",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "missing-value",
           "type": "structure",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "required-constraint",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "pattern-constraint",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "non-castable-value",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "unique-constraint",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "enumerable-constraint",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "minimum-constraint",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "maximum-constraint",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "minimum-length-constraint",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         },
         {
           "code": "maximum-length-constraint",
           "type": "schema",
-          "context": "body"
+          "context": "body",
+          "description": ""
         }
     ]
 }

--- a/goodtables/spec.json
+++ b/goodtables/spec.json
@@ -22,6 +22,11 @@
           "context": "dataset"
         },
         {
+          "code": "source-error",
+          "type": "general",
+          "context": "table"
+        },
+        {
           "code": "scheme-error",
           "type": "general",
           "context": "table"

--- a/goodtables/spec.json
+++ b/goodtables/spec.json
@@ -3,37 +3,37 @@
     "errors": [
         {
           "code": "io-error",
-          "type": "source",
+          "type": "general",
           "context": "any"
         },
         {
           "code": "http-error",
-          "type": "source",
+          "type": "general",
           "context": "any"
         },
         {
           "code": "datapackage-error",
-          "type": "source",
+          "type": "general",
           "context": "dataset"
         },
         {
           "code": "jsontableschema-error",
-          "type": "source",
+          "type": "general",
           "context": "dataset"
         },
         {
           "code": "scheme-error",
-          "type": "source",
+          "type": "general",
           "context": "table"
         },
         {
           "code": "format-error",
-          "type": "source",
+          "type": "general",
           "context": "table"
         },
         {
           "code": "encoding-error",
-          "type": "source",
+          "type": "general",
           "context": "table"
         },
         {

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import goodtables
+
+
+def test_register():
+    pass

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import io
+import json
+import requests
+
+
+def test_spec_is_up_to_date():
+    actual = json.load(io.open('goodtables/spec.json', encoding='utf-8'))
+    expect = requests.get('https://raw.githubusercontent.com/frictionlessdata/data-quality-spec/master/spec.json').json()
+    assert actual == expect, 'run `make spec` to update the spec'


### PR DESCRIPTION
- fixes #131 

---

Here the simplest approach to achieve 2 goals:
- spec could be updated using bash command (`make spec`)
- goodtables can't be released with outdated data quality specification