### PR TITLE
Added source information to report

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ print(inspector.inspect('data/invalid.csv'))
 #     'valid': False',
 #     'headers': ['id', 'name', ''],
 #     'row-count': 4,
+#     'source': 'data/invalid.csv'
 #     'error-count': 2,
 #     'errors': [
 #        {'row': None,
@@ -135,6 +136,7 @@ def custom_preset(source, **options):
     for table in source:
         try:
             tables.append({
+                'source':  str(source),
                 'stream':  Stream(...),
                 'schema': Schema(...),
                 'extra': {...},

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -131,6 +131,7 @@ class Inspector(object):
         row_number = 0
         fatal_error = False
         checks = copy(self.__checks)
+        source = table['source']
         stream = table['stream']
         schema = table['schema']
         extra = table['extra']
@@ -240,6 +241,7 @@ class Inspector(object):
             'error-count': len(errors),
             'row-count': row_number,
             'headers': headers,
+            'source': source,
             'errors': errors,
         })
 

--- a/goodtables/presets/table.py
+++ b/goodtables/presets/table.py
@@ -8,6 +8,7 @@ import jsontableschema
 from tabulator import Stream
 from jsontableschema import Schema, validate
 from ..register import preset
+from ..spec import spec
 
 
 # Module API
@@ -19,17 +20,24 @@ def table(source, schema=None, **options):
 
     # Prepare schema
     if schema is not None:
-        # https://github.com/frictionlessdata/jsontableschema-py/issues/113
-        from jsontableschema.helpers import load_json_source
-        schema = load_json_source(schema)
+        descriptor = schema
         try:
-            validate(schema, no_fail_fast=True)
-            schema = Schema(schema)
+            # https://github.com/frictionlessdata/jsontableschema-py/issues/113
+            from jsontableschema.helpers import load_json_source
+            loaded_descriptor = load_json_source(schema)
+            validate(loaded_descriptor, no_fail_fast=True)
+            schema = Schema(loaded_descriptor)
         except jsontableschema.exceptions.MultipleInvalid as exception:
             for error in exception.errors:
+                # Error message should contain schema source (often it's path)
+                message = spec['errors']['jsontableschema-error']['message']
+                message = message.format(
+                    error_message='{problem} [{source}]'.format(
+                        problem=str(error).splitlines()[0],
+                        source=str(descriptor)))
                 errors.append({
                     'code': 'jsontableschema-error',
-                    'message': str(error).splitlines()[0],
+                    'message': message,
                     'row-number': None,
                     'column-number': None,
                 })
@@ -38,6 +46,7 @@ def table(source, schema=None, **options):
     if not errors:
         options.setdefault('headers', 1)
         tables.append({
+            'source': str(source),
             'stream': Stream(source, **options),
             'schema': schema,
             'extra': {},


### PR DESCRIPTION
- fixes #122 
- rebases `jsontableschema/datapackage-error` on spec messages and added information about path where validation error has happened

---

So now gt.io will be able to show file paths in job reports:

```
{'error-count': 2,
 'errors': [],
 'table-count': 2,
 'tables': [{'datapackage': 'data/datapackages/invalid/datapackage.json',
             'error-count': 1,
             'errors': [{'code': 'blank-row',
                         'column-number': None,
                         'message': 'Row 3 is completely blank',
                         'row': [],
                         'row-number': 3}],
             'headers': ['id', 'name', 'description', 'amount'],
             'row-count': 4,
             'source': '/home/roll/projects/goodtables-py/data/datapackages/invalid/data.csv',
             'time': 0.004,
             'valid': False},
            {'datapackage': 'data/datapackages/invalid/datapackage.json',
             'error-count': 1,
             'errors': [{'code': 'blank-row',
                         'column-number': None,
                         'message': 'Row 4 is completely blank',
                         'row': [],
                         'row-number': 4}],
             'headers': ['parent', 'comment'],
             'row-count': 5,
             'source': '/home/roll/projects/goodtables-py/data/datapackages/invalid/data2.csv',
             'time': 0.002,
             'valid': False}],
 'time': 0.02,
 'valid': False}
```