### PR TITLE
Added support for datapackages preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Goodtables by default supports the following presets:
 - table
 - tables
 - datapackage
+- datapackages
 
 #### Custom presets
 

--- a/examples/datapackages.py
+++ b/examples/datapackages.py
@@ -3,7 +3,7 @@ from goodtables import Inspector
 
 inspector = Inspector()
 report = inspector.inspect([
-    {'source': 'data/datapackages/valid/datapackage.json'},
+    'data/datapackages/valid/datapackage.json',
     {'source': 'data/datapackages/invalid/datapackage.json'},
 ], preset='datapackages')
 pprint(report)

--- a/examples/datapackages.py
+++ b/examples/datapackages.py
@@ -1,0 +1,9 @@
+from pprint import pprint
+from goodtables import Inspector
+
+inspector = Inspector()
+report = inspector.inspect([
+    {'source': 'data/datapackages/valid/datapackage.json'},
+    {'source': 'data/datapackages/invalid/datapackage.json'},
+], preset='datapackages')
+pprint(report)

--- a/examples/tables.py
+++ b/examples/tables.py
@@ -3,7 +3,7 @@ from goodtables import Inspector
 
 inspector = Inspector()
 report = inspector.inspect([
+    'data/invalid.csv',
     {'source': 'data/valid.csv', 'schema': {'fields': [{'name': 'id'}, {'name': 'name'}]}},
-    {'source': 'data/invalid.csv'},
 ], preset='tables')
 pprint(report)

--- a/features/datapackages.yml
+++ b/features/datapackages.yml
@@ -1,6 +1,6 @@
 datapackages:
   source:
-    - source: data/datapackages/valid/datapackage.json
+    - data/datapackages/valid/datapackage.json
     - source: data/datapackages/invalid/datapackage.json
   preset: datapackages
   report:

--- a/features/datapackages.yml
+++ b/features/datapackages.yml
@@ -1,0 +1,8 @@
+datapackages:
+  source:
+    - source: data/datapackages/valid/datapackage.json
+    - source: data/datapackages/invalid/datapackage.json
+  preset: datapackages
+  report:
+    - [3, 3, null, 'blank-row']
+    - [4, 4, null, 'blank-row']

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -67,7 +67,9 @@ class Inspector(object):
             preset (str): dataset extraction preset
                 supported presets:
                     - table
+                    - tables
                     - datapackage
+                    - datapackages
             options (dict): source options
 
         Returns:

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -93,7 +93,7 @@ class Inspector(object):
 
         # Collect reports
         reports = []
-        if not errors:
+        if tables:
             tasks = []
             pool = ThreadPool(processes=len(tables))
             for table in tables:

--- a/goodtables/presets/__init__.py
+++ b/goodtables/presets/__init__.py
@@ -5,5 +5,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from .datapackage import datapackage
+from .datapackages import datapackages
 from .table import table
 from .tables import tables

--- a/goodtables/presets/datapackages.py
+++ b/goodtables/presets/datapackages.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from copy import deepcopy
+from .datapackage import datapackage as datapackage_preset
+from ..register import preset
+
+
+# Module API
+
+@preset('datapackages')
+def datapackages(items):
+    errors = []
+    tables = []
+
+    # Add errors, tables
+    items = deepcopy(items)
+    for item in items:
+        source = item.pop('source')
+        item_errors, item_tables = datapackage_preset(source, **item)
+        errors.extend(item_errors)
+        tables.extend(item_tables)
+
+    return errors, tables

--- a/goodtables/presets/datapackages.py
+++ b/goodtables/presets/datapackages.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import six
 from copy import deepcopy
 from .datapackage import datapackage as datapackage_preset
 from ..register import preset
@@ -19,8 +20,11 @@ def datapackages(items):
     # Add errors, tables
     items = deepcopy(items)
     for item in items:
-        source = item.pop('source')
-        item_errors, item_tables = datapackage_preset(source, **item)
+        if isinstance(item, six.string_types):
+            item_errors, item_tables = datapackage_preset(item)
+        else:
+            source = item.pop('source')
+            item_errors, item_tables = datapackage_preset(source, **item)
         errors.extend(item_errors)
         tables.extend(item_tables)
 

--- a/goodtables/presets/tables.py
+++ b/goodtables/presets/tables.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from copy import deepcopy
 from .table import table as table_preset
 from ..register import preset
 
@@ -16,6 +17,7 @@ def tables(items):
     tables = []
 
     # Add errors, tables
+    items = deepcopy(items)
     for item in items:
         source = item.pop('source')
         item_errors, item_tables = table_preset(source, **item)

--- a/goodtables/presets/tables.py
+++ b/goodtables/presets/tables.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import six
 from copy import deepcopy
 from .table import table as table_preset
 from ..register import preset
@@ -19,8 +20,11 @@ def tables(items):
     # Add errors, tables
     items = deepcopy(items)
     for item in items:
-        source = item.pop('source')
-        item_errors, item_tables = table_preset(source, **item)
+        if isinstance(item, six.string_types):
+            item_errors, item_tables = table_preset(item)
+        else:
+            source = item.pop('source')
+            item_errors, item_tables = table_preset(source, **item)
         errors.extend(item_errors)
         tables.extend(item_tables)
 

--- a/tests/presets/test_datapackages.py
+++ b/tests/presets/test_datapackages.py
@@ -11,7 +11,7 @@ from goodtables import presets
 
 def test_datapackages():
     errors, tables = presets.datapackages([
-        {'source': 'data/datapackages/valid/datapackage.json'},
+        'data/datapackages/valid/datapackage.json',
         {'source': 'data/datapackages/invalid/datapackage.json'},
     ])
     assert len(errors) == 0

--- a/tests/presets/test_datapackages.py
+++ b/tests/presets/test_datapackages.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from goodtables import presets
+
+
+# Test
+
+def test_datapackages():
+    errors, tables = presets.datapackages([
+        {'source': 'data/datapackages/valid/datapackage.json'},
+        {'source': 'data/datapackages/invalid/datapackage.json'},
+    ])
+    assert len(errors) == 0
+    assert len(tables) == 4

--- a/tests/presets/test_tables.py
+++ b/tests/presets/test_tables.py
@@ -11,7 +11,7 @@ from goodtables import presets
 
 def test_tables():
     errors, tables = presets.tables([
-        {'source': 'data/valid.csv'},
+        'data/valid.csv',
         {'source': 'data/invalid.csv'},
     ])
     assert len(errors) == 0

--- a/tests/presets/test_tables.py
+++ b/tests/presets/test_tables.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from goodtables import presets
+
+
+# Test
+
+def test_tables():
+    errors, tables = presets.tables([
+        {'source': 'data/valid.csv'},
+        {'source': 'data/invalid.csv'},
+    ])
+    assert len(errors) == 0
+    assert len(tables) == 2


### PR DESCRIPTION
- fixes #153 
- minor changes to `tables` preset (deepcopy input, unit test)
- allow further inspection even if there are dataset-level errors (if one of datapackages is invalid others will be inspected anyway)
- allow short source form for tables and datapackages presets