### PR TITLE
Disallow shorthand syntax for tables/datapackages presets

### DIFF
--- a/examples/datapackages.py
+++ b/examples/datapackages.py
@@ -3,7 +3,7 @@ from goodtables import Inspector
 
 inspector = Inspector()
 report = inspector.inspect([
-    'data/datapackages/valid/datapackage.json',
+    {'source': 'data/datapackages/valid/datapackage.json'},
     {'source': 'data/datapackages/invalid/datapackage.json'},
 ], preset='datapackages')
 pprint(report)

--- a/examples/tables.py
+++ b/examples/tables.py
@@ -3,7 +3,7 @@ from goodtables import Inspector
 
 inspector = Inspector()
 report = inspector.inspect([
-    'data/invalid.csv',
     {'source': 'data/valid.csv', 'schema': {'fields': [{'name': 'id'}, {'name': 'name'}]}},
+    {'source': 'data/invalid.csv'},
 ], preset='tables')
 pprint(report)

--- a/features/datapackages.yml
+++ b/features/datapackages.yml
@@ -1,6 +1,6 @@
 datapackages:
   source:
-    - data/datapackages/valid/datapackage.json
+    - source: data/datapackages/valid/datapackage.json
     - source: data/datapackages/invalid/datapackage.json
   preset: datapackages
   report:

--- a/goodtables/presets/datapackages.py
+++ b/goodtables/presets/datapackages.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import six
 from copy import deepcopy
 from .datapackage import datapackage as datapackage_preset
 from ..register import preset
@@ -20,11 +19,8 @@ def datapackages(items):
     # Add errors, tables
     items = deepcopy(items)
     for item in items:
-        if isinstance(item, six.string_types):
-            item_errors, item_tables = datapackage_preset(item)
-        else:
-            source = item.pop('source')
-            item_errors, item_tables = datapackage_preset(source, **item)
+        source = item.pop('source')
+        item_errors, item_tables = datapackage_preset(source, **item)
         errors.extend(item_errors)
         tables.extend(item_tables)
 

--- a/goodtables/presets/tables.py
+++ b/goodtables/presets/tables.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import six
 from copy import deepcopy
 from .table import table as table_preset
 from ..register import preset
@@ -20,11 +19,8 @@ def tables(items):
     # Add errors, tables
     items = deepcopy(items)
     for item in items:
-        if isinstance(item, six.string_types):
-            item_errors, item_tables = table_preset(item)
-        else:
-            source = item.pop('source')
-            item_errors, item_tables = table_preset(source, **item)
+        source = item.pop('source')
+        item_errors, item_tables = table_preset(source, **item)
         errors.extend(item_errors)
         tables.extend(item_tables)
 

--- a/tests/presets/test_datapackages.py
+++ b/tests/presets/test_datapackages.py
@@ -11,7 +11,7 @@ from goodtables import presets
 
 def test_datapackages():
     errors, tables = presets.datapackages([
-        'data/datapackages/valid/datapackage.json',
+        {'source': 'data/datapackages/valid/datapackage.json'},
         {'source': 'data/datapackages/invalid/datapackage.json'},
     ])
     assert len(errors) == 0

--- a/tests/presets/test_tables.py
+++ b/tests/presets/test_tables.py
@@ -11,7 +11,7 @@ from goodtables import presets
 
 def test_tables():
     errors, tables = presets.tables([
-        'data/valid.csv',
+        {'source': 'data/valid.csv'},
         {'source': 'data/invalid.csv'},
     ])
     assert len(errors) == 0


### PR DESCRIPTION
- it disallows string syntax for sources (revert back to version `v1.0.0-alpha5`)