### PR TITLE
Catch all stream exceptions

### DIFF
--- a/data/latin1.csv
+++ b/data/latin1.csv
@@ -1,0 +1,3 @@
+id,name
+1,english
+2,©

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -166,7 +166,11 @@ class Inspector(object):
             elif isinstance(exception, tabulator.exceptions.HTTPError):
                 code = 'http-error'
             else:
-                raise
+                # In the perfect world `tabulator` should catch and wrap 100%
+                # of all possible errors (providing error type as exception class).
+                # But for now it's not achieved yet so we fallback here to source error:
+                # https://github.com/frictionlessdata/tabulator-py/issues/167
+                code = 'source-error'
             errors.append({
                 'row': None,
                 'code': code,

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ def read(*paths):
 PACKAGE = 'goodtables'
 NAME = PACKAGE.replace('_', '-')
 INSTALL_REQUIRES = [
-    'six>=1.9,<2.0a',
-    'click>=6.6,<7.0a',
-    'requests>=2.10,<3.0a',
-    'tabulator>=0.10,<1.0a',
-    'jsontableschema>=0.8.2,<1.0a',
-    'datapackage>=0.8,<1.0a',
+    'six>=1.9,<2.0',
+    'click>=6.6,<7.0',
+    'requests>=2.10,<3.0',
+    'tabulator[ods]>=1.0.0a4,<2.0',
+    'jsontableschema>=0.8.2,<1.0',
+    'datapackage>=0.8,<1.0',
 ]
 TESTS_REQUIRE = [
     'pylama',

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -106,9 +106,12 @@ def test_inspector_tables_invalid(log):
 def test_inspector_catch_all_open_exceptions(log):
     inspector = Inspector()
     report = inspector.inspect('data/latin1.csv', encoding='utf-8')
+    assert log(report) == [
+        (1, None, None, 'source-error'),
+    ]
 
 
 def test_inspector_catch_all_iter_exceptions(log):
     inspector = Inspector()
-    # Resucing sample size here to get raise on iter, not on open
-    report = inspector.inspect([['h'], [1], 'bad'], sample_size=2)
+    # Reducing sample size to get raise on iter, not on open
+    report = inspector.inspect([['h'], [1], 'bad'], sample_size=1)

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -115,3 +115,6 @@ def test_inspector_catch_all_iter_exceptions(log):
     inspector = Inspector()
     # Reducing sample size to get raise on iter, not on open
     report = inspector.inspect([['h'], [1], 'bad'], sample_size=1)
+    assert log(report) == [
+        (1, None, None, 'source-error'),
+    ]

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -99,3 +99,16 @@ def test_inspector_tables_invalid(log):
         (2, 5, 3, 'non-castable-value'),
         (2, 5, 4, 'non-castable-value'),
     ]
+
+
+# Tests [exceptions]
+
+def test_inspector_catch_all_open_exceptions(log):
+    inspector = Inspector()
+    report = inspector.inspect('data/latin1.csv', encoding='utf-8')
+
+
+def test_inspector_catch_all_iter_exceptions(log):
+    inspector = Inspector()
+    # Resucing sample size here to get raise on iter, not on open
+    report = inspector.inspect([['h'], [1], 'bad'], sample_size=2)


### PR DESCRIPTION
- fixes #189 (by `tabulator` version update)
- improves related to #189 behavior:
  - now `goodtables` catches all errors on `stream.open` (even if `tabulator` has missed it)
  - now `goodtables` catches all errors on `stream.iter` (if e.g. encoding error is outside of sample size lines stream could fail on iter not on open)