### PR TITLE
Fix off-by-one errors in extra_header check

### DIFF
--- a/goodtables/checks/extra_header.py
+++ b/goodtables/checks/extra_header.py
@@ -31,8 +31,8 @@ class ExtraHeader(object):
                 column_sample = []
                 for row in sample:
                     value = None
-                    if len(row) > cell['number']:
-                        value = row[cell['number']]
+                    if len(row) >= cell['number']:
+                        value = row[cell['number'] - 1]
                     column_sample.append(value)
                 schema = Schema()
                 schema.infer(column_sample, headers=[cell['header']])

--- a/tests/checks/test_extra_header.py
+++ b/tests/checks/test_extra_header.py
@@ -44,6 +44,28 @@ def test_check_extra_header_infer(log):
     assert cells[1]['field'].name == 'name2'
 
 
+def test_check_extra_header_infer_with_data(log):
+    errors = []
+    cells = [
+        {'number': 1,
+         'header': 'name1',
+         'field': Field({'name': 'name1'})},
+        {'number': 2,
+         'header': 'name2'},
+    ]
+    sample = [
+        ['123', 'abc'],
+        ['456', 'def'],
+        ['789', 'ghi'],
+    ]
+    extra_header = ExtraHeader(infer_fields=True)
+    extra_header.check_headers(errors, cells, sample=sample)
+    assert log(errors) == []
+    assert len(cells) == 2
+    assert cells[1]['field'].name == 'name2'
+    assert cells[1]['field'].type == 'string'
+
+
 def test_check_extra_header_problem(log):
     errors = []
     cells = [


### PR DESCRIPTION
Comparison misses the edge case where the extra column has data in it

Resulting assignment does not account for the fact that the column
numbers are 1-indexed while python lists are 0-indexed.