### PR TITLE
[#250] Fix bug with truncated-values check on date fields

### DIFF
--- a/goodtables/contrib/checks/truncated_value.py
+++ b/goodtables/contrib/checks/truncated_value.py
@@ -38,7 +38,7 @@ class TruncatedValue(object):
                 value = int(value)
                 if value in _TRUNCATED_INTEGER_VALUES:
                     truncated = True
-            except ValueError:
+            except Exception:
                 pass
 
             # Add error


### PR DESCRIPTION
The problem was that `int(date_value)` raises a `TypeError`, and we were only
catching `ValueError`. As we don't care about the specific exception, just that
no exception is thrown, I changed to catch all exceptions.

Fixes #250