### PR TITLE
Add message parameter values to error info dict

### DIFF
--- a/goodtables/error.py
+++ b/goodtables/error.py
@@ -106,4 +106,5 @@ class Error(object):
             'row-number': self.row_number,
             'column-number': self.column_number,
             'message': self.message,
+            'message-data': {k: v.strip('"') for k, v in self._message_substitutions.items()},
         }

--- a/goodtables/error.py
+++ b/goodtables/error.py
@@ -106,5 +106,6 @@ class Error(object):
             'row-number': self.row_number,
             'column-number': self.column_number,
             'message': self.message,
-            'message-data': {k: v.strip('"') for k, v in self._message_substitutions.items()},
+            'message-data': {k: v.strip('"') if isinstance(v, str) else v for k, v
+                             in self._message_substitutions.items()},
         }

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -42,6 +42,7 @@ class TestError(object):
         error = Error(error_code, message=message, message_substitutions=message_substitutions)
 
         assert error.message == '31 foobar'
+        assert dict(error)['message-data'] == {'foo': 31, 'bar': 'foobar'}
 
     def test_to_dict(self, error_code, cell):
         row_number = 51
@@ -53,6 +54,7 @@ class TestError(object):
             'row-number': row_number,
             'column-number': cell['column-number'],
             'message': error.message,
+            'message-data': {}
         }
         assert dict(error) == expected_dict
 


### PR DESCRIPTION
Add message parameter values to error information dict (key `message-data`). This allows alternative usage of error description.

Before:
```json
{
    "code": "type-or-format-error",
    "column-number": 8,
    "message": "The value \"5500,20\" in row 4 and column 8 is not type \"number\" and format \"default\"",
    "row-number": 4
},

```
After:
```json
{
    "code": "type-or-format-error",
    "column-number": 8,
    "message": "The value \"5500,20\" in row 4 and column 8 is not type \"number\" and format \"default\"",
    "message-data": {
        "field_format": "default",
        "field_type": "number",
        "value": "5500,20"
    },
    "row-number": 4
},

```
