### PR TITLE
Pass raw data to error message_substitutions

### DIFF
--- a/goodtables/checks/constraints_checks.py
+++ b/goodtables/checks/constraints_checks.py
@@ -26,8 +26,8 @@ def create_check_constraint(check, constraint):
             # Add error
             if not valid:
                 message_substitutions = {
-                    'value': '"{}"'.format(value),
-                    'constraint': '"{}"'.format(field.constraints[constraint]),
+                    'value': value,
+                    'constraint': field.constraints[constraint],
                 }
 
                 error = Error(

--- a/goodtables/checks/duplicate_header.py
+++ b/goodtables/checks/duplicate_header.py
@@ -31,9 +31,10 @@ def duplicate_header(cells, sample=None):
             continue
 
         for header_index in sorted(header_indexes)[1:]:
-            duplicates = header_indexes - {header_index}
+            duplicates = sorted(header_indexes - {header_index})
             message_substitutions = {
-                'column_numbers': ', '.join(map(str, duplicates)),
+                'column_numbers': duplicates,
+                'column_numbers_str': ', '.join(map(str, duplicates)),
             }
             error = Error(
                 'duplicate-header',

--- a/goodtables/checks/duplicate_row.py
+++ b/goodtables/checks/duplicate_row.py
@@ -37,7 +37,8 @@ class DuplicateRow(object):
             # Add error
             if references:
                 message_substitutions = {
-                    'row_numbers': ', '.join(map(str, references)),
+                    'row_numbers': references,
+                    'row_numbers_str': ', '.join(map(str, references)),
                 }
                 error = Error(
                     'duplicate-row',

--- a/goodtables/checks/non_matching_header.py
+++ b/goodtables/checks/non_matching_header.py
@@ -63,7 +63,7 @@ def _check_without_ordering(cells):
             if header != cell['field'].name:
                 # Add error
                 message_substitutions = {
-                    'field_name': '"{}"'.format(cell['field'].name),
+                    'field_name': cell['field'].name,
                 }
                 error = Error(
                     'non-matching-header',

--- a/goodtables/checks/type_or_format_error.py
+++ b/goodtables/checks/type_or_format_error.py
@@ -38,9 +38,9 @@ def type_or_format_error(cells):
 
         # Add error
         message_substitutions = {
-            'value': '"{}"'.format(value),
-            'field_type': '"{}"'.format(field.type),
-            'field_format': '"{}"'.format(field.format),
+            'value': value,
+            'field_type': field.type,
+            'field_format': field.format,
         }
         error = Error(
             'type-or-format-error',

--- a/goodtables/checks/unique_constraint.py
+++ b/goodtables/checks/unique_constraint.py
@@ -38,8 +38,10 @@ class UniqueConstraint(object):
             all_values_are_none = (set(column_values) == {None})
             if not all_values_are_none:
                 if column_values in cache['data']:
+                    row_numbers = cache['refs'] + [row_number]
                     message_substitutions = {
-                        'row_numbers': ', '.join(map(str, cache['refs'] + [row_number])),
+                        'row_numbers': row_numbers,
+                        'row_numbers_str': ', '.join(map(str, row_numbers)),
                     }
 
                     # FIXME: The unique constraint can be related to multiple

--- a/goodtables/error.py
+++ b/goodtables/error.py
@@ -110,6 +110,5 @@ class Error(object):
             'row-number': self.row_number,
             'column-number': self.column_number,
             'message': self.message,
-            'message-data': {k: v.strip('"') if isinstance(v, str) else v for k, v
-                             in self._message_substitutions.items()},
+            'message-data': self._message_substitutions,
         }

--- a/goodtables/spec.json
+++ b/goodtables/spec.json
@@ -66,7 +66,7 @@
           "type": "structure",
           "context": "head",
           "weight": 3,
-          "message": "Header in column {column_number} is duplicated to header in column(s) {column_numbers}",
+          "message": "Header in column {column_number} is duplicated to header in column(s) {column_numbers_str}",
           "description": "Two columns in the header row have the same value. Column names should be unique.\n\n How it could be resolved:\n - Add the missing column name to the first row of the data.\n - If the first row starts with, or ends with a comma, remove it.\n - If this error should be ignored disable `duplicate-header` check in {validator}."
         },
         "blank-row": {
@@ -82,7 +82,7 @@
           "type": "structure",
           "context": "body",
           "weight": 5,
-          "message": "Row {row_number} is duplicated to row(s) {row_numbers}",
+          "message": "Row {row_number} is duplicated to row(s) {row_numbers_str}",
           "description": "The exact same data has been seen in another row.\n\n How it could be resolved:\n - If some of the data is incorrect, correct it.\n - If the whole row is an incorrect duplicate, remove it.\n - If this error should be ignored disable `duplicate-row` check in {validator}."
         },
         "extra-value": {
@@ -116,7 +116,7 @@
           "type": "schema",
           "context": "head",
           "weight": 9,
-          "message": "Header in column {column_number} doesn't match field name {field_name} in the schema",
+          "message": "Header in column {column_number} doesn't match field name \"{field_name}\" in the schema",
           "description": "One of the data source headers doesn't match the field name defined in the schema.\n\n How it could be resolved:\n - Rename header in the data source or field in the schema\n - If this error should be ignored disable `non-matching-header` check in {validator}."
         },
         "extra-header": {
@@ -140,7 +140,7 @@
           "type": "schema",
           "context": "body",
           "weight": 9,
-          "message": "The value {value} in row {row_number} and column {column_number} is not type {field_type} and format {field_format}",
+          "message": "The value \"{value}\" in row {row_number} and column {column_number} is not type \"{field_type}\" and format \"{field_format}\"",
           "description": "The value does not match the schema type and format for this field.\n\n How it could be resolved:\n - If this value is not correct, update the value.\n - If this value is correct, adjust the type and/or format.\n - To ignore the error, disable the `type-or-format-error` check in {validator}. In this case all schema checks for row values will be ignored."
         },
         "required-constraint": {
@@ -156,7 +156,7 @@
           "type": "schema",
           "context": "body",
           "weight": 7,
-          "message": "The value {value} in row {row_number} and column {column_number} does not conform to the pattern constraint of {constraint}",
+          "message": "The value \"{value}\" in row {row_number} and column {column_number} does not conform to the pattern constraint of \"{constraint}\"",
           "description": "This field value should conform to constraint pattern.\n\n How it could be resolved:\n - If this value is not correct, update the value.\n - If value is correct, then remove or refine the `pattern` constraint in the schema.\n - If this error should be ignored disable `pattern-constraint` check in {validator}."
         },
         "unique-constraint": {
@@ -164,7 +164,7 @@
           "type": "schema",
           "context": "body",
           "weight": 9,
-          "message": "Rows {row_numbers} has unique constraint violation in column {column_number}",
+          "message": "Rows {row_numbers_str} has unique constraint violation in column {column_number}",
           "description": "This field is a unique field but it contains a value that has been used in another row.\n\n How it could be resolved:\n - If this value is not correct, update the value.\n - If value is correct, then the values in this column are not unique. Remove the `unique` constraint from the schema.\n - If this error should be ignored disable `unique-constraint` check in {validator}."
         },
         "enumerable-constraint": {
@@ -172,7 +172,7 @@
           "type": "schema",
           "context": "body",
           "weight": 7,
-          "message": "The value {value} in row {row_number} and column {column_number} does not conform to the given enumeration: {constraint}",
+          "message": "The value \"{value}\" in row {row_number} and column {column_number} does not conform to the given enumeration: \"{constraint}\"",
           "description": "This field value should be equal to one of the values in the enumeration constraint.\n\n How it could be resolved:\n - If this value is not correct, update the value.\n - If value is correct, then remove or refine the `enum` constraint in the schema.\n - If this error should be ignored disable `enumerable-constraint` check in {validator}."
         },
         "minimum-constraint": {
@@ -180,7 +180,7 @@
           "type": "schema",
           "context": "body",
           "weight": 7,
-          "message": "The value {value} in row {row_number} and column {column_number} does not conform to the minimum constraint of {constraint}",
+          "message": "The value \"{value}\" in row {row_number} and column {column_number} does not conform to the minimum constraint of \"{constraint}\"",
           "description": "This field value should be greater or equal than constraint value.\n\n How it could be resolved:\n - If this value is not correct, update the value.\n - If value is correct, then remove or refine the `minimum` constraint in the schema.\n - If this error should be ignored disable `minimum-constraint` check in {validator}."
         },
         "maximum-constraint": {
@@ -188,7 +188,7 @@
           "type": "schema",
           "context": "body",
           "weight": 7,
-          "message": "The value {value} in row {row_number} and column {column_number} does not conform to the maximum constraint of {constraint}",
+          "message": "The value \"{value}\" in row {row_number} and column {column_number} does not conform to the maximum constraint of \"{constraint}\"",
           "description": "This field value should be less or equal than constraint value.\n\n How it could be resolved:\n - If this value is not correct, update the value.\n - If value is correct, then remove or refine the `maximum` constraint in the schema.\n - If this error should be ignored disable `maximum-constraint` check in {validator}."
         },
         "minimum-length-constraint": {
@@ -196,7 +196,7 @@
           "type": "schema",
           "context": "body",
           "weight": 7,
-          "message": "The value {value} in row {row_number} and column {column_number} does not conform to the minimum length constraint of {constraint}",
+          "message": "The value \"{value}\" in row {row_number} and column {column_number} does not conform to the minimum length constraint of \"{constraint}\"",
           "description": "A length of this field value should be greater or equal than schema constraint value.\n\n How it could be resolved:\n - If this value is not correct, update the value.\n - If value is correct, then remove or refine the `minimumLength` constraint in the schema.\n - If this error should be ignored disable `minimum-length-constraint` check in {validator}."
         },
         "maximum-length-constraint": {
@@ -204,7 +204,7 @@
           "type": "schema",
           "context": "body",
           "weight": 7,
-          "message": "The value {value} in row {row_number} and column {column_number} does not conform to the maximum length constraint of {constraint}",
+          "message": "The value \"{value}\" in row {row_number} and column {column_number} does not conform to the maximum length constraint of \"{constraint}\"",
           "description": "A length of this field value should be less or equal than schema constraint value.\n\n How it could be resolved:\n - If this value is not correct, update the value.\n - If value is correct, then remove or refine the `maximumLength` constraint in the schema.\n - If this error should be ignored disable `maximum-length-constraint` check in {validator}."
         }
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -33,16 +33,19 @@ class TestError(object):
         assert error.message == expected_message
 
     def test_message_substitutes_extra_values(self, error_code):
-        message = '{foo} {bar}'
+        message = '{foo} {bar} {values_str}'
         message_substitutions = {
             'foo': 31,
             'bar': 'foobar',
+            'values': ["foo", 'bar'],
+            'values_str': ", ".join(["foo", 'bar']),
         }
 
         error = Error(error_code, message=message, message_substitutions=message_substitutions)
 
-        assert error.message == '31 foobar'
-        assert dict(error)['message-data'] == {'foo': 31, 'bar': 'foobar'}
+        assert error.message == "31 foobar foo, bar"
+        assert dict(error)['message-data'] == {'foo': 31, 'bar': 'foobar',
+                                               'values': ['foo', 'bar'], 'values_str': 'foo, bar'}
 
     def test_to_dict(self, error_code, cell):
         row_number = 51


### PR DESCRIPTION
I'm building a UI using goodtables-py as a dependency, and I need to display raw data which is currently prisoner of the error message string.

For example, I would like to display a `<ul>` of all possible values of an enum constraint.

The previous pull request #280 allowed to export `messages_substitutions` as `message-data` in error dict.
But many checks format values (using `", ".join` for example), making those data difficult to reuse.

This pull request modifies those checks to expose data and a formatted version of the data (for example exposing both keys `column_numbers` and `column_numbers_str`) and removes the stripping of quotes which become unnecessary.

I also modified `spec.json` to add quotes in the message string.

I noticed that this approach is already adopted in custom checks (example in [`blacklisted_value.py`](https://github.com/frictionlessdata/goodtables-py/blob/7778d1e3630f4ab95dfb76d13106c9733d4ec4c0/goodtables/contrib/checks/blacklisted_value.py#L45-L51)).