### PR TITLE
terminate thread pool after execution completes.  causes thread leak

### DIFF
--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -83,6 +83,7 @@ class Inspector(object):
                 table_warnings, table_report = task.get()
                 warnings.extend(table_warnings)
                 table_reports.append(table_report)
+        pool.terminate()
 
         # Stop timer
         stop = datetime.datetime.now()

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -77,13 +77,15 @@ class Inspector(object):
         if tables:
             tasks = []
             pool = ThreadPool(processes=len(tables))
-            for table in tables:
-                tasks.append(pool.apply_async(self.__inspect_table, (table,)))
-            for task in tasks:
-                table_warnings, table_report = task.get()
-                warnings.extend(table_warnings)
-                table_reports.append(table_report)
-            pool.terminate()
+            try:
+                for table in tables:
+                    tasks.append(pool.apply_async(self.__inspect_table, (table,)))
+                for task in tasks:
+                    table_warnings, table_report = task.get()
+                    warnings.extend(table_warnings)
+                    table_reports.append(table_report)
+            finally:
+                pool.terminate()
 
         # Stop timer
         stop = datetime.datetime.now()

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -83,7 +83,7 @@ class Inspector(object):
                 table_warnings, table_report = task.get()
                 warnings.extend(table_warnings)
                 table_reports.append(table_report)
-        pool.terminate()
+            pool.terminate()
 
         # Stop timer
         stop = datetime.datetime.now()


### PR DESCRIPTION
this was causing memory leaks and serious performance degradation when validating small batches of records, as threads were never released.