### PR TITLE
Handle tableschema CastError in required constraint

### DIFF
--- a/goodtables/checks/required_constraint.py
+++ b/goodtables/checks/required_constraint.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from copy import copy
+import tableschema
 from ..registry import check
 from ..error import Error
 
@@ -27,7 +28,12 @@ def required_constraint(cells):
         # Check constraint
         valid = field.test_value(value, constraints=['required'])
         if field.descriptor.get('primaryKey'):
-            valid = valid and field.cast_value(value) is not None
+            try:
+                casted_value = field.cast_value(value)
+            except tableschema.exceptions.TableSchemaException:
+                valid = False
+            else:
+                valid = valid and casted_value is not None
 
         # Skip if valid
         if valid:


### PR DESCRIPTION
Fixes #300 

Here is my proposition. Running the same command than the one in #300 does:

```bash
goodtables validate --schema https://raw.githubusercontent.com/etalab/schema.data.gouv.fr/4acda7bb7d1904617d87ddb1fe31ee3503a8c61b/decp-dpa/schema.json https://git.opendatafrance.net/validata/validata-core/uploads/c6b57d0ed336b74383886e330d5da81f/test.csv                        

DATASET
=======
{'error-count': 1,
 'preset': 'nested',
 'table-count': 1,
 'time': 0.665,
 'valid': False}

TABLE [1]
=========
{'encoding': 'cp852',
 'error-count': 1,
 'format': 'csv',
 'headers': ['siretAcheteur', 'urlProfilAcheteur', 'urlDCAT', 'coordonnnees'],
 'row-count': 2,
 'schema': 'table-schema',
 'scheme': 'https',
 'source': 'https://git.opendatafrance.net/validata/validata-core/uploads/c6b57d0ed336b74383886e330d5da81f/test.csv',
 'time': 0.387,
 'valid': False}
---------
[2,1] [required-constraint] Column 1 is a required field, but row 2 has no value
```

It is better now because there is no more a stack trace, but an error report. It could be better, in this case, returning a `pattern-constraint` error rather than a `required-constraint` but perhaps it's another subject.
