### PR TITLE
Allow non-required primary keys

### DIFF
--- a/goodtables/checks/required_constraint.py
+++ b/goodtables/checks/required_constraint.py
@@ -26,7 +26,7 @@ def required_constraint(cells):
 
         # Check constraint
         valid = field.test_value(value, constraints=['required'])
-        if field.descriptor.get('primaryKey'):
+        if field.descriptor.get('primaryKey') and field.constraints.get('required', True):
             valid = valid and field.cast_value(value) is not None
 
         # Skip if valid

--- a/tests/checks/test_required_constraint.py
+++ b/tests/checks/test_required_constraint.py
@@ -4,13 +4,52 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from tableschema import Field
 from goodtables.checks.required_constraint import required_constraint
+import goodtables.cells
 
-
-# Check
 
 def test_check_required_constraint(log):
-    cells = []
-    errors = required_constraint(cells)
-    assert log(errors) == []
-    assert len(cells) == 0
+    cell = goodtables.cells.create_cell(
+        'id',
+        '',
+        field=Field({
+            'name': 'id',
+            'constraints': {
+                'required': True,
+            }
+        })
+    )
+    errors = required_constraint([cell])
+    assert len(errors) == 1
+    assert errors[0].code == 'required-constraint'
+
+
+def test_primary_key_fields_are_required_by_default(log):
+    cell = goodtables.cells.create_cell(
+        'id',
+        '',
+        field=Field({
+            'name': 'id',
+            'primaryKey': True,
+        })
+    )
+    errors = required_constraint([cell])
+    assert len(errors) == 1
+    assert errors[0].code == 'required-constraint'
+
+
+def test_primary_keys_required_constraint_can_be_overloaded(log):
+    cell = goodtables.cells.create_cell(
+        'id',
+        '',
+        field=Field({
+            'name': 'id',
+            'constraints': {
+                'required': False,
+            },
+            'primaryKey': True,
+        })
+    )
+    errors = required_constraint([cell])
+    assert not errors


### PR DESCRIPTION
per https://github.com/frictionlessdata/specs/pull/642

If a field is a `primaryKey`, by default it cannot be `null`; that is, we assume that `{'constraints': {'required': True}}`. This commit allows the default behavior to be overloaded by explicitly setting `required: false`:

```json
"fields": [
  {
    "name": "id",
    "constraints": {
      "required": false
    }
  }
],
"primaryKey": "id"
```

Fixes #251