### PR TITLE
161 support optional fields

### DIFF
--- a/goodtables/cells.py
+++ b/goodtables/cells.py
@@ -1,13 +1,17 @@
 from six.moves import zip_longest
 
 
-def create_cells(headers, schema_fields, values=None, row_number=None):
+def create_cells(headers, schema_fields, optional_fields, values=None, row_number=None):
     """Create list of cells from headers, fields and values.
 
     Args:
         headers (List[str]): The headers values.
         schema_fields (List[tableschema.field.Field]): The tableschema
             fields.
+        optional_fields (List[str]): List of schema fields which are defined as
+            optional. This has the effect that a field defined as optional and
+            is missing from the header and values, will not create a cell for
+            that field.
         values (List[Any], optional): The cells values. If not specified,
             the created cells will have the same values as their
             corresponding headers. This is useful for specifying headers
@@ -35,6 +39,15 @@ def create_cells(headers, schema_fields, values=None, row_number=None):
             field = None
         if value == fillvalue:
             value = None
+
+        # Only allow optional fields to be ignored if there is no header or value
+        # defined.
+        # - If both of them are defined, then don't ignore it.
+        # - If either of them are defined separately, then indicates a structural
+        #   error, so leave the cell to be created and let them be checked
+        if (header is None and value is None and
+                field and field.name in optional_fields):
+            continue
 
         cell = create_cell(header, value, field, column_number, row_number)
         cells.append(cell)

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -28,10 +28,11 @@ class Inspector(object):
 
     def __init__(self,
                  checks=['structure', 'schema'],
-                 skip_checks=[],
+                 skip_checks=None,
                  infer_schema=False,
                  infer_fields=False,
                  order_fields=False,
+                 optional_fields=None,
                  error_limit=config.DEFAULT_ERROR_LIMIT,
                  table_limit=config.DEFAULT_TABLE_LIMIT,
                  row_limit=config.DEFAULT_ROW_LIMIT):
@@ -40,10 +41,11 @@ class Inspector(object):
 
         # Set attributes
         self.__checks = checks
-        self.__skip_checks = skip_checks
+        self.__skip_checks = skip_checks if skip_checks is not None else []
         self.__infer_schema = infer_schema
         self.__infer_fields = infer_fields
         self.__order_fields = order_fields
+        self.__optional_fields = optional_fields if optional_fields is not None else []
 
         parse_limit = lambda num: float('inf') if (num < 0) else num  # noqa:E731
         self.__error_limit = parse_limit(error_limit)
@@ -213,7 +215,7 @@ class Inspector(object):
             fields = [None] * len(headers)
             if schema is not None:
                 fields = schema.fields
-            header_cells = cells.create_cells(headers, fields)
+            header_cells = cells.create_cells(headers, fields, self.__optional_fields)
 
             has_headers = (None not in headers)
             if has_headers:
@@ -244,7 +246,7 @@ class Inspector(object):
                         error, fatal_error = _compose_error_from_exception(exception)
                         errors.append(error)
                         break
-                    row_cells = cells.create_cells(headers, fields, row, row_number)
+                    row_cells = cells.create_cells(headers, fields, self.__optional_fields, row, row_number)
                     for check in body_checks:
                         if not row_cells:
                             break

--- a/goodtables/validate.py
+++ b/goodtables/validate.py
@@ -35,6 +35,10 @@ def validate(source, **options):
         order_fields (bool): Order source columns based on schema fields order.
             This is useful when you don't want to validate that the data
             columns' order is the same as the schema's.
+        optional_fields (List[str]): List of fields defined in the schema which
+            are optional. Structural checks are still enforced for optional columns
+            (i.e. missing optional header but values still supplied, breaking
+            extra-value check). Any optional_fields not in the schema will be ignored
         error_limit (int): Stop validation if the number of errors per table
             exceeds this value.
         table_limit (int): Maximum number of tables to validate.
@@ -117,6 +121,7 @@ def _parse_arguments(source, **options):
         'infer_schema',
         'infer_fields',
         'order_fields',
+        'optional_fields',
         'error_limit',
         'table_limit',
         'row_limit',

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -1,6 +1,17 @@
 import pytest
 import goodtables.cells
 
+class MockField(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, other):
+        if isinstance(other, MockField):
+            return self.name == other.name
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 class TestCells(object):
     def test_create_header_cells(self):
@@ -92,6 +103,60 @@ class TestCells(object):
         ]
 
         assert cells == [dict(cell) for cell in expected_cells]
+
+    def test_create_cell_for_optional_field_that_is_present(self):
+        headers = [
+            'header1',
+            'header2'
+        ]
+        schema_fields = [
+            MockField('header1'),
+            MockField('header2')
+        ]
+        optional_fields = ['header2']
+
+        cells = goodtables.cells.create_cells(headers, schema_fields, optional_fields)
+        expected_cells = [
+            goodtables.cells.create_cell('header1', 'header1', MockField('header1'), 1),
+            goodtables.cells.create_cell('header2', 'header2', MockField('header2'), 2)
+        ]
+
+        assert cells == expected_cells
+
+    def test_cell_not_created_for_optional_value_that_is_not_present(self):
+        headers = [
+            'header1',
+        ]
+        schema_fields = [
+            MockField('header1'),
+            MockField('header2')
+        ]
+        optional_fields = ['header2']
+
+        cells = goodtables.cells.create_cells(headers, schema_fields, optional_fields)
+        expected_cells = [
+            goodtables.cells.create_cell('header1', 'header1', MockField('header1'), 1),
+        ]
+
+        assert cells == expected_cells
+        
+    def test_cell_created_when_field_in_schema_but_is_not_optional(self):
+        headers = [
+            'header1',
+        ]
+        schema_fields = [
+            MockField('header1'),
+            MockField('header2')
+        ]
+        optional_fields = []
+
+        cells = goodtables.cells.create_cells(headers, schema_fields, optional_fields)
+        expected_cells = [
+            goodtables.cells.create_cell('header1', 'header1', MockField('header1'), 1),
+            goodtables.cells.create_cell(None, None, MockField('header2'), 2)
+        ]
+
+        assert cells == expected_cells
 
     def test_dict_has_expected_keys(self, cell):
         expected_keys = [

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -14,8 +14,9 @@ class TestCells(object):
             'name_schema',
             'value_schema',
         ]
+        optional_fields = []
 
-        cells = goodtables.cells.create_cells(headers, schema_fields)
+        cells = goodtables.cells.create_cells(headers, schema_fields, optional_fields)
         expected_cells = [
             goodtables.cells.create_cell('name', 'name', 'name_schema', 1),
             goodtables.cells.create_cell('value', 'value', 'value_schema', 2),
@@ -36,8 +37,9 @@ class TestCells(object):
             'Jane',
             51,
         ]
+        optional_fields = []
 
-        cells = goodtables.cells.create_cells(headers, schema_fields, values)
+        cells = goodtables.cells.create_cells(headers, schema_fields, optional_fields, values)
         expected_cells = [
             goodtables.cells.create_cell('name', 'Jane', 'name_schema', 1),
             goodtables.cells.create_cell('value', 51, 'value_schema', 2),
@@ -57,8 +59,9 @@ class TestCells(object):
         values = [
             'Jane',
         ]
+        optional_fields = []
 
-        cells = goodtables.cells.create_cells(headers, schema_fields, values)
+        cells = goodtables.cells.create_cells(headers, schema_fields, optional_fields, values)
         expected_cells = [
             goodtables.cells.create_cell('name', 'Jane', 'name_schema', 1),
             goodtables.cells.create_cell('value', None, 'value_schema', 2),
@@ -80,8 +83,9 @@ class TestCells(object):
             None,
             51,
         ]
+        optional_fields = []
 
-        cells = goodtables.cells.create_cells(headers, schema_fields, values)
+        cells = goodtables.cells.create_cells(headers, schema_fields, optional_fields, values)
         expected_cells = [
             goodtables.cells.create_cell('name', None, 'name_schema', 1),
             goodtables.cells.create_cell('value', 51, 'value_schema', 2),


### PR DESCRIPTION
# Overview

First pass at supporting optional fields via passing a list through `validate`. Does this by not creating the cells for optional fields which are defined in the schema, but the header and value for that field are not present. Not sure if this is the best way forward for optional fields, or if there are some unintended consequences of doing it this way as i'm still unfamiliar with the overall system, so input is welcome.

---

Please preserve this line to notify @roll (lead of this repository)
