### PR TITLE
Generate API Reference from docstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ list:
 
 readme:
 	pip install md-toc
-	md_toc -p README.md github --header-levels 4
+	pip install referencer
+	referencer $(PACKAGE) README.md --in-place
+	md_toc -p README.md github --header-levels 3
 	sed -i '/(#$(PACKAGE)-py)/,+2d' README.md
 
 release:

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ report_data2 = validate('data2.csv')
 The difference is that goodtables validates multiple tables in parallel, so
 calling using the "nested" preset should run faster.
 
-### Errors
+### Data Quality Errors
 
 Base report errors are standardized and described in
 [Data Quality Spec](https://github.com/frictionlessdata/data-quality-spec/blob/master/spec.json).

--- a/README.md
+++ b/README.md
@@ -632,25 +632,6 @@ __Arguments__
         extra arguments will be passed on to `tabulator`_, if it is
         `datapackage`, they will be passed on to the `datapackage`_
         constructor.
-- __schema (Union[str, Dict, IO])__:
-        The Table Schema for the source.
-- __headers (Union[int, List[str])__:
-        Either the row number that contains
-        the headers, or a list with them. If the row number is given, ?????
-- __scheme (str)__:
-        The scheme used to access the source (e.g. `file`,
-        `http`). This is usually inferred correctly from the source. See
-        the `tabulator`_ documentation for the list of supported schemes.
-- __format (str)__:
-        Format of the source data (`csv`, `datapackage`, ...).
-        This is usually inferred correctly from the source. See the
-        the `tabulator`_ documentation for the list of supported formats.
-- __encoding (str)__:
-        Encoding of the source.
-- __skip_rows (Union[int, List[Union[int, str]]])__:
-        Row numbers or a
-        string. Rows beginning with the string will be ignored (e.g. '#',
-        '//').
 
 __Raises__
 - `GoodtablesException`: Raised on any non-tabular error.
@@ -735,7 +716,7 @@ dict(**kwargs) -> new dictionary initialized with the name=value pairs
 ```python
 GoodtablesException(self, /, *args, **kwargs)
 ```
-https://github.com/frictionlessdata/goodtables-py#exceptions
+Base goodtables exception
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,7 @@ library.
 
 The output of the `validate()` method is a report dictionary. It includes
 information if the data was valid, count of errors, list of table reports, which
-individual checks failed, etc.
-
-Resulting report will be looking like this:
+individual checks failed, etc. A report will be looking like this:
 
 ```json
 {
@@ -213,7 +211,7 @@ calling using the "nested" preset should run faster.
 Base report errors are standardized and described in
 [Data Quality Spec](https://github.com/frictionlessdata/data-quality-spec/blob/master/spec.json).
 
-#### Basic errors
+#### Source errors
 
 The basic checks can't be disabled, as they deal with goodtables being able to read the files.
 
@@ -226,7 +224,7 @@ The basic checks can't be disabled, as they deal with goodtables being able to r
 | format-error | Data reading error because of incorrect format. |
 | encoding-error | Data reading error because of an encoding problem. |
 
-#### Structural errors
+#### Structure errors
 
 These checks validate that the structure of the file are valid.
 
@@ -263,7 +261,7 @@ Lastly, if the order of the fields in the data is different than in your schema,
 | minimum-length-constraint | A length of this field value should be greater or equal than schema constraint value. |
 | maximum-length-constraint | A length of this field value should be less or equal than schema constraint value. |
 
-#### Advanced errors
+#### Custom errors
 
 | check | description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ of your data (e.g. all rows have the same number of columns), and its contents
     - [Data Quality Errors](#data-quality-errors)
     - [Frequently Asked Questions](#frequently-asked-questions)
   - [API Reference](#api-reference)
+    - [`cli`](#cli)
     - [`validate`](#validate)
     - [`preset`](#preset)
     - [`check`](#check)
@@ -580,6 +581,25 @@ report = validate(source, preset='custom-preset')
 For now this documentation section is incomplete. Please see builtin presets to learn more about the dataset extraction protocol.
 
 ## API Reference
+
+### `cli`
+```python
+cli()
+```
+Command-line interface
+
+```
+Usage: cli.py [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+
+Commands:
+  validate*  Validate tabular files (default).
+  init       Init data package from list of files.
+```
+
 
 ### `validate`
 ```python

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ of your data (e.g. all rows have the same number of columns), and its contents
     - [Report](#report)
     - [Checks](#checks)
     - [Presets](#presets)
-    - [Errors](#errors)
+    - [Data Quality Errors](#data-quality-errors)
     - [Frequently Asked Questions](#frequently-asked-questions)
   - [API Reference](#api-reference)
     - [`validate`](#validate)
@@ -589,8 +589,10 @@ validate(source, **options)
 ```
 Validates a source file and returns a report.
 
-Args:
-    source (Union[str, Dict, List[Dict], IO]): The source to be validated.
+__Arguments__
+
+- __source (Union[str, Dict, List[Dict], IO])__:
+        The source to be validated.
         It can be a local file path, URL, dict, list of dicts, or a
         file-like object. If it's a list of dicts and the `preset` is
         "nested", each of the dict key's will be used as if it was passed
@@ -598,91 +600,126 @@ Args:
 
         The file can be a CSV, XLS, JSON, and any other format supported by
         `tabulator`_.
-
-Keyword Args:
-    checks (List[str]): List of checks names to be enabled. They can be
+- __checks (List[str])__:
+        List of checks names to be enabled. They can be
         individual check names (e.g. `blank-headers`), or check types (e.g.
         `structure`).
-    skip_checks (List[str]): List of checks names to be skipped. They can
+- __skip_checks (List[str])__:
+        List of checks names to be skipped. They can
         be individual check names (e.g. `blank-headers`), or check types
         (e.g.  `structure`).
-    infer_schema (bool): Infer schema if one wasn't passed as an argument.
-    infer_fields (bool): Infer schema for columns not present in the received schema.
-    order_fields (bool): Order source columns based on schema fields order.
+- __infer_schema (bool)__:
+        Infer schema if one wasn't passed as an argument.
+- __infer_fields (bool)__:
+        Infer schema for columns not present in the received schema.
+- __order_fields (bool)__:
+        Order source columns based on schema fields order.
         This is useful when you don't want to validate that the data
         columns' order is the same as the schema's.
-    error_limit (int): Stop validation if the number of errors per table
-        exceeds this value.
-    table_limit (int): Maximum number of tables to validate.
-    row_limit (int): Maximum number of rows to validate.
-
-    preset (str): Dataset type could be `table` (default), `datapackage`,
+- __error_limit (int)__:
+        Stop validation if the number of errors per table exceeds this value.
+- __table_limit (int)__:
+        Maximum number of tables to validate.
+- __row_limit (int)__:
+        Maximum number of rows to validate.
+- __preset (str)__:
+        Dataset type could be `table` (default), `datapackage`,
         `nested` or custom. Usually, the preset can be inferred from the
         source, so you don't need to define it.
-    Any (Any): Any additional arguments not defined here will be passed on,
+- __Any (Any)__:
+        Any additional arguments not defined here will be passed on,
         depending on the chosen `preset`. If the `preset` is `table`, the
         extra arguments will be passed on to `tabulator`_, if it is
         `datapackage`, they will be passed on to the `datapackage`_
         constructor.
-
-    # Table preset
-    schema (Union[str, Dict, IO]): The Table Schema for the
-        source.
-    headers (Union[int, List[str]): Either the row number that contains
+- __schema (Union[str, Dict, IO])__:
+        The Table Schema for the source.
+- __headers (Union[int, List[str])__:
+        Either the row number that contains
         the headers, or a list with them. If the row number is given, ?????
-    scheme (str): The scheme used to access the source (e.g. `file`,
+- __scheme (str)__:
+        The scheme used to access the source (e.g. `file`,
         `http`). This is usually inferred correctly from the source. See
         the `tabulator`_ documentation for the list of supported schemes.
-    format (str): Format of the source data (`csv`, `datapackage`, ...).
+- __format (str)__:
+        Format of the source data (`csv`, `datapackage`, ...).
         This is usually inferred correctly from the source. See the
         the `tabulator`_ documentation for the list of supported formats.
-    encoding (str): Encoding of the source.
-    skip_rows (Union[int, List[Union[int, str]]]): Row numbers or a
+- __encoding (str)__:
+        Encoding of the source.
+- __skip_rows (Union[int, List[Union[int, str]]])__:
+        Row numbers or a
         string. Rows beginning with the string will be ignored (e.g. '#',
         '//').
 
-Raises:
-    GoodtablesException: Raised on any non-tabular error.
+__Raises__
+- `GoodtablesException`: Raised on any non-tabular error.
 
-Returns:
-    dict: The validation report.
+__Returns__
 
-.. _tabulator:
-    https://github.com/frictionlessdata/tabulator-py
-.. _tabulator_schemes:
-    https://github.com/frictionlessdata/tabulator-py
-.. _tabulator:
-    https://github.com/frictionlessdata/datapackage-py
+`dict`: The validation report.
+
 
 ### `preset`
 ```python
 preset(name)
 ```
-https://github.com/frictionlessdata/goodtables-py#custom-presets
+Register a custom preset (decorator)
+
+__Example__
+
+
+```python
+@preset('custom-preset')
+def custom_preset(source, **options):
+    # ...
+```
+
+__Arguments__
+- __name (str)__: preset name
+
 
 ### `check`
 ```python
 check(name, type=None, context=None, position=None)
 ```
-https://github.com/frictionlessdata/goodtables-py#custom-checks
+Register a custom check (decorator)
+
+__Example__
+
+
+```python
+@check('custom-check', type='custom', context='body')
+def custom_check(cells):
+    # ...
+```
+
+__Arguments__
+- __name (str)__: preset name
+- __type (str)__: has to be `custom`
+- __context (str)__: has to be `head` or `body`
+- __position (str)__: has to be `before:<check-name>` or `after:<check-name>`
+
 
 ### `Error`
 ```python
 Error(self, code, cell=None, row_number=None, message=None, message_substitutions=None)
 ```
-Describes a validation check error.
+Describes a validation check error
 
-Args:
-    code (str): The error code. Must be one in the spec.
-    cell (dict, optional): The cell where the error occurred.
-    row_number (int, optional): The row number where the error occurs.
-    message (str, optional The error message. Defaults to the message from
-        the Data Quality Spec.
-    message_substitutions (dict, optional Dictionary with substitutions to
-        be used when generating the error message and description.
+__Arguments__
+- __code (str)__: The error code. Must be one in the spec.
+- __cell (dict, optional)__: The cell where the error occurred.
+- __row_number (int, optional)__: The row number where the error occurs.
+- __message (str, optional)__:
+        The error message. Defaults to the message from the Data Quality Spec.
+- __message_substitutions (dict, optional)__:
+        Dictionary with substitutions to be used when
+        generating the error message and description.
 
-Raises:
-    KeyError: Raised if the error code isn't known.
+__Raises__
+- `KeyError`: Raised if the error code isn't known.
+
 
 ### `spec`
 dict() -> new empty dictionary

--- a/goodtables/__init__.py
+++ b/goodtables/__init__.py
@@ -16,6 +16,12 @@ from .error import Error
 from .spec import spec
 from .exceptions import GoodtablesException
 
+# Deprecated
+
+from . import (exceptions,)
+from .cli import (init_datapackage,)
+from .inspector import (Inspector,)
+
 # Register
 
 import importlib
@@ -24,9 +30,3 @@ for module in config.PRESETS:
     importlib.import_module(module)
 for module in config.CHECKS:
     importlib.import_module(module)
-
-# Deprecated
-
-from . import (exceptions,)
-from .cli import (init_datapackage,)
-from .inspector import (Inspector,)

--- a/goodtables/__init__.py
+++ b/goodtables/__init__.py
@@ -3,24 +3,18 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from . import config
+__version__ = config.VERSION
 
 
 # Module API
 
-from .inspector import Inspector
-from .registry import preset, check
-from .validate import validate, init_datapackage
-from .spec import spec
+from .validate import validate
+from .registry import preset
+from .registry import check
 from .error import Error
-from . import exceptions
-
-# Version
-
-import io
-import os
-__version__ = io.open(
-    os.path.join(os.path.dirname(__file__), 'VERSION'),
-    encoding='utf-8').read().strip()
+from .spec import spec
+from .exceptions import GoodtablesException
 
 # Register
 
@@ -30,3 +24,9 @@ for module in config.PRESETS:
     importlib.import_module(module)
 for module in config.CHECKS:
     importlib.import_module(module)
+
+# Deprecated
+
+from . import (exceptions,)
+from .cli import (init_datapackage,)
+from .inspector import (Inspector,)

--- a/goodtables/__init__.py
+++ b/goodtables/__init__.py
@@ -9,7 +9,11 @@ __version__ = config.VERSION
 
 # Module API
 
-from .cli import cli
+# TODO: somethin wrong goes on with cli here
+# The same pattern with `__main__/cli` works fine for tabulator/tableschema/datapackage
+# There we don't need to have `__name__ == "__main__":` in cli.py
+# And following line doesn't lead to a warning
+# from .cli import cli
 from .validate import validate
 from .registry import preset
 from .registry import check

--- a/goodtables/__init__.py
+++ b/goodtables/__init__.py
@@ -9,6 +9,7 @@ __version__ = config.VERSION
 
 # Module API
 
+from .cli import cli
 from .validate import validate
 from .registry import preset
 from .registry import check
@@ -19,7 +20,7 @@ from .exceptions import GoodtablesException
 # Deprecated
 
 from . import (exceptions,)
-from .cli import (init_datapackage,)
+from .helpers import (init_datapackage,)
 from .inspector import (Inspector,)
 
 # Register

--- a/goodtables/__main__.py
+++ b/goodtables/__main__.py
@@ -1,0 +1,7 @@
+from .cli import cli
+
+
+# Module API
+
+if __name__ == "__main__":
+    cli()

--- a/goodtables/cli.py
+++ b/goodtables/cli.py
@@ -10,27 +10,30 @@ import json as json_module
 from pprint import pformat
 from datapackage import Package
 from click_default_group import DefaultGroup
+from .helpers import init_datapackage
 from . import config
 click.disable_unicode_literals_warning = True
 
 
 # Module API
 
-@click.group(cls=DefaultGroup, default='validate', default_if_no_args=True)
+@click.group(cls=DefaultGroup, default='validate', default_if_no_args=True, help='')
 @click.version_option(config.VERSION, message='%(version)s')
 def cli():
-    """Tabular files validator.
+    """Command-line interface
 
-    There are two categories of validation checks available:
+    ```
+    Usage: cli.py [OPTIONS] COMMAND [ARGS]...
 
-    * Structural checks: ensure there are no empty rows, no blank headers, etc.
+    Options:
+      --version  Show the version and exit.
+      --help     Show this message and exit.
 
-    * Content checks: ensure the values have the correct types (e.g. string),
-      their format is valid (e.g. e-mail), and they respect some constraint
-      (e.g. age is greater than 18).
+    Commands:
+      validate*  Validate tabular files (default).
+      init       Init data package from list of files.
+    ```
 
-    \b
-    Full documentation at: <https://github.com/frictionlessdata/goodtables-py/>
     """
     pass
 
@@ -171,24 +174,3 @@ def _print_report(report, output=None, json=False):
             }
             message = template.format(**substitutions)
             secho(message)
-
-
-# Internal
-
-def init_datapackage(resource_paths):
-    # "Create tabular data package with resources.
-    dp = Package({
-        'name': 'change-me',
-        'schema': 'tabular-data-package',
-    })
-
-    for path in resource_paths:
-        dp.infer(path)
-
-    return dp
-
-
-# Main program
-
-if __name__ == '__main__':
-    cli()

--- a/goodtables/cli.py
+++ b/goodtables/cli.py
@@ -5,17 +5,19 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import click
-from click_default_group import DefaultGroup
 import goodtables
 import json as json_module
 from pprint import pformat
+from datapackage import Package
+from click_default_group import DefaultGroup
+from . import config
 click.disable_unicode_literals_warning = True
 
 
 # Module API
 
 @click.group(cls=DefaultGroup, default='validate', default_if_no_args=True)
-@click.version_option(goodtables.__version__, message='%(version)s')
+@click.version_option(config.VERSION, message='%(version)s')
 def cli():
     """Tabular files validator.
 
@@ -123,7 +125,7 @@ def init(paths, output, **kwargs):
 
     It will also infer tabular data's schemas from their contents.
     """
-    dp = goodtables.init_datapackage(paths)
+    dp = init_datapackage(paths)
 
     click.secho(
         json_module.dumps(dp.descriptor, indent=4),
@@ -169,6 +171,21 @@ def _print_report(report, output=None, json=False):
             }
             message = template.format(**substitutions)
             secho(message)
+
+
+# Internal
+
+def init_datapackage(resource_paths):
+    # "Create tabular data package with resources.
+    dp = Package({
+        'name': 'change-me',
+        'schema': 'tabular-data-package',
+    })
+
+    for path in resource_paths:
+        dp.infer(path)
+
+    return dp
 
 
 # Main program

--- a/goodtables/cli.py
+++ b/goodtables/cli.py
@@ -173,3 +173,8 @@ def _print_report(report, output=None, json=False):
             }
             message = template.format(**substitutions)
             secho(message)
+
+# Main
+
+if __name__ == "__main__":
+    cli()

--- a/goodtables/cli.py
+++ b/goodtables/cli.py
@@ -8,7 +8,6 @@ import click
 import goodtables
 import json as json_module
 from pprint import pformat
-from datapackage import Package
 from click_default_group import DefaultGroup
 from .helpers import init_datapackage
 from . import config

--- a/goodtables/cli.py
+++ b/goodtables/cli.py
@@ -174,6 +174,7 @@ def _print_report(report, output=None, json=False):
             message = template.format(**substitutions)
             secho(message)
 
+
 # Main
 
 if __name__ == "__main__":

--- a/goodtables/config.py
+++ b/goodtables/config.py
@@ -4,9 +4,13 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import io
+import os
+
 
 # General
 
+VERSION = io.open(os.path.join(os.path.dirname(__file__), 'VERSION')).read().strip()
 DEFAULT_ERROR_LIMIT = 1000
 DEFAULT_TABLE_LIMIT = 10
 DEFAULT_ROW_LIMIT = 1000

--- a/goodtables/error.py
+++ b/goodtables/error.py
@@ -10,19 +10,21 @@ from .spec import spec
 
 @functools.total_ordering
 class Error(object):
-    """Describes a validation check error.
+    """Describes a validation check error
 
-    Args:
+    # Arguments
         code (str): The error code. Must be one in the spec.
         cell (dict, optional): The cell where the error occurred.
         row_number (int, optional): The row number where the error occurs.
-        message (str, optional The error message. Defaults to the message from
-            the Data Quality Spec.
-        message_substitutions (dict, optional Dictionary with substitutions to
-            be used when generating the error message and description.
+        message (str, optional):
+            The error message. Defaults to the message from the Data Quality Spec.
+        message_substitutions (dict, optional):
+            Dictionary with substitutions to be used when
+            generating the error message and description.
 
-    Raises:
+    # Raises
         KeyError: Raised if the error code isn't known.
+
     """
 
     def __init__(

--- a/goodtables/exceptions.py
+++ b/goodtables/exceptions.py
@@ -8,6 +8,6 @@ from __future__ import unicode_literals
 # Base
 
 class GoodtablesException(Exception):
-    """https://github.com/frictionlessdata/goodtables-py#exceptions
+    """Base goodtables exception
     """
     pass

--- a/goodtables/helpers.py
+++ b/goodtables/helpers.py
@@ -1,0 +1,16 @@
+from datapackage import Package
+
+
+# Module API
+
+def init_datapackage(resource_paths):
+    # "Create tabular data package with resources.
+    dp = Package({
+        'name': 'change-me',
+        'schema': 'tabular-data-package',
+    })
+
+    for path in resource_paths:
+        dp.infer(path)
+
+    return dp

--- a/goodtables/inspector.py
+++ b/goodtables/inspector.py
@@ -35,8 +35,6 @@ class Inspector(object):
                  error_limit=config.DEFAULT_ERROR_LIMIT,
                  table_limit=config.DEFAULT_TABLE_LIMIT,
                  row_limit=config.DEFAULT_ROW_LIMIT):
-        """https://github.com/frictionlessdata/goodtables-py#inspector
-        """
 
         # Set attributes
         self.__checks = checks
@@ -51,8 +49,6 @@ class Inspector(object):
         self.__row_limit = parse_limit(row_limit)
 
     def inspect(self, source, preset=None, **options):
-        """https://github.com/frictionlessdata/goodtables-py#inspector
-        """
 
         # Start timer
         start = datetime.datetime.now()

--- a/goodtables/registry.py
+++ b/goodtables/registry.py
@@ -15,7 +15,19 @@ from . import exceptions
 # Module API
 
 def preset(name):
-    """https://github.com/frictionlessdata/goodtables-py#custom-presets
+    """Register a custom preset (decorator)
+
+    # Example
+
+    ```python
+    @preset('custom-preset')
+    def custom_preset(source, **options):
+        # ...
+    ```
+
+    # Arguments
+        name (str): preset name
+
     """
     def decorator(func):
         registry.register_preset(func, name)
@@ -24,7 +36,22 @@ def preset(name):
 
 
 def check(name, type=None, context=None, position=None):
-    """https://github.com/frictionlessdata/goodtables-py#custom-checks
+    """Register a custom check (decorator)
+
+    # Example
+
+    ```python
+    @check('custom-check', type='custom', context='body')
+    def custom_check(cells):
+        # ...
+    ```
+
+    # Arguments
+        name (str): preset name
+        type (str): has to be `custom`
+        context (str): has to be `head` or `body`
+        position (str): has to be `before:<check-name>` or `after:<check-name>`
+
     """
     def decorator(func):
         registry.register_check(func, name, type, context, position)

--- a/goodtables/validate.py
+++ b/goodtables/validate.py
@@ -66,31 +66,6 @@ def validate(source, **options):
             `datapackage`, they will be passed on to the `datapackage`_
             constructor.
 
-        schema (Union[str, Dict, IO]):
-            The Table Schema for the source.
-
-        headers (Union[int, List[str]):
-            Either the row number that contains
-            the headers, or a list with them. If the row number is given, ?????
-
-        scheme (str):
-            The scheme used to access the source (e.g. `file`,
-            `http`). This is usually inferred correctly from the source. See
-            the `tabulator`_ documentation for the list of supported schemes.
-
-        format (str):
-            Format of the source data (`csv`, `datapackage`, ...).
-            This is usually inferred correctly from the source. See the
-            the `tabulator`_ documentation for the list of supported formats.
-
-        encoding (str):
-            Encoding of the source.
-
-        skip_rows (Union[int, List[Union[int, str]]]):
-            Row numbers or a
-            string. Rows beginning with the string will be ignored (e.g. '#',
-            '//').
-
     # Raises
         GoodtablesException: Raised on any non-tabular error.
 

--- a/goodtables/validate.py
+++ b/goodtables/validate.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import datapackage
 from .inspector import Inspector
 
 
@@ -86,27 +85,6 @@ def validate(source, **options):
 
     return report
 
-
-def init_datapackage(resource_paths):
-    """Create tabular data package with resources.
-
-    It will also infer the tabular resources' schemas.
-
-    Args:
-        resource_paths (List[str]): Paths to the data package resources.
-
-    Returns:
-        datapackage.Package: The data package.
-    """
-    dp = datapackage.Package({
-        'name': 'change-me',
-        'schema': 'tabular-data-package',
-    })
-
-    for path in resource_paths:
-        dp.infer(path)
-
-    return dp
 
 
 def _parse_arguments(source, **options):

--- a/goodtables/validate.py
+++ b/goodtables/validate.py
@@ -12,8 +12,10 @@ from .inspector import Inspector
 def validate(source, **options):
     """Validates a source file and returns a report.
 
-    Args:
-        source (Union[str, Dict, List[Dict], IO]): The source to be validated.
+    # Arguments
+
+        source (Union[str, Dict, List[Dict], IO]):
+            The source to be validated.
             It can be a local file path, URL, dict, list of dicts, or a
             file-like object. If it's a list of dicts and the `preset` is
             "nested", each of the dict key's will be used as if it was passed
@@ -22,60 +24,79 @@ def validate(source, **options):
             The file can be a CSV, XLS, JSON, and any other format supported by
             `tabulator`_.
 
-    Keyword Args:
-        checks (List[str]): List of checks names to be enabled. They can be
+        checks (List[str]):
+            List of checks names to be enabled. They can be
             individual check names (e.g. `blank-headers`), or check types (e.g.
             `structure`).
-        skip_checks (List[str]): List of checks names to be skipped. They can
+
+        skip_checks (List[str]):
+            List of checks names to be skipped. They can
             be individual check names (e.g. `blank-headers`), or check types
             (e.g.  `structure`).
-        infer_schema (bool): Infer schema if one wasn't passed as an argument.
-        infer_fields (bool): Infer schema for columns not present in the received schema.
-        order_fields (bool): Order source columns based on schema fields order.
+
+        infer_schema (bool):
+            Infer schema if one wasn't passed as an argument.
+
+        infer_fields (bool):
+            Infer schema for columns not present in the received schema.
+
+        order_fields (bool):
+            Order source columns based on schema fields order.
             This is useful when you don't want to validate that the data
             columns' order is the same as the schema's.
-        error_limit (int): Stop validation if the number of errors per table
-            exceeds this value.
-        table_limit (int): Maximum number of tables to validate.
-        row_limit (int): Maximum number of rows to validate.
 
-        preset (str): Dataset type could be `table` (default), `datapackage`,
+        error_limit (int):
+            Stop validation if the number of errors per table exceeds this value.
+
+        table_limit (int):
+            Maximum number of tables to validate.
+
+        row_limit (int):
+            Maximum number of rows to validate.
+
+        preset (str):
+            Dataset type could be `table` (default), `datapackage`,
             `nested` or custom. Usually, the preset can be inferred from the
             source, so you don't need to define it.
-        Any (Any): Any additional arguments not defined here will be passed on,
+
+        Any (Any):
+            Any additional arguments not defined here will be passed on,
             depending on the chosen `preset`. If the `preset` is `table`, the
             extra arguments will be passed on to `tabulator`_, if it is
             `datapackage`, they will be passed on to the `datapackage`_
             constructor.
 
-        # Table preset
-        schema (Union[str, Dict, IO]): The Table Schema for the
-            source.
-        headers (Union[int, List[str]): Either the row number that contains
+        schema (Union[str, Dict, IO]):
+            The Table Schema for the source.
+
+        headers (Union[int, List[str]):
+            Either the row number that contains
             the headers, or a list with them. If the row number is given, ?????
-        scheme (str): The scheme used to access the source (e.g. `file`,
+
+        scheme (str):
+            The scheme used to access the source (e.g. `file`,
             `http`). This is usually inferred correctly from the source. See
             the `tabulator`_ documentation for the list of supported schemes.
-        format (str): Format of the source data (`csv`, `datapackage`, ...).
+
+        format (str):
+            Format of the source data (`csv`, `datapackage`, ...).
             This is usually inferred correctly from the source. See the
             the `tabulator`_ documentation for the list of supported formats.
-        encoding (str): Encoding of the source.
-        skip_rows (Union[int, List[Union[int, str]]]): Row numbers or a
+
+        encoding (str):
+            Encoding of the source.
+
+        skip_rows (Union[int, List[Union[int, str]]]):
+            Row numbers or a
             string. Rows beginning with the string will be ignored (e.g. '#',
             '//').
 
-    Raises:
+    # Raises
         GoodtablesException: Raised on any non-tabular error.
 
-    Returns:
+    # Returns
         dict: The validation report.
 
-    .. _tabulator:
-        https://github.com/frictionlessdata/tabulator-py
-    .. _tabulator_schemes:
-        https://github.com/frictionlessdata/tabulator-py
-    .. _tabulator:
-        https://github.com/frictionlessdata/datapackage-py
     """
     source, options, inspector_settings = _parse_arguments(source, **options)
 

--- a/goodtables/validate.py
+++ b/goodtables/validate.py
@@ -86,7 +86,6 @@ def validate(source, **options):
     return report
 
 
-
 def _parse_arguments(source, **options):
     # Extract settings
     validation_options = set((

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'goodtables = goodtables.cli:cli',
+            'goodtables = goodtables.__main__:cli',
         ]
     },
     zip_safe=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,21 +11,21 @@ except ImportError:
 import json
 import datapackage
 from click.testing import CliRunner
-import goodtables.cli
+from goodtables.cli import cli, init
 
 
 # Tests
 
 def test_cli_version():
     runner = CliRunner()
-    result = runner.invoke(goodtables.cli.cli, ['--version'])
+    result = runner.invoke(cli, ['--version'])
     assert result.exit_code == 0
     assert len(result.output.split('.')) == 3
 
 
 @mock.patch('goodtables.validate', autospec=True)
 def test_cli_infer_schema_enables_infer_fields(validate_mock):
-    CliRunner().invoke(goodtables.cli.cli, ['--infer-schema', 'data.csv'])
+    CliRunner().invoke(cli, ['--infer-schema', 'data.csv'])
 
     last_call_args = validate_mock.call_args
     assert last_call_args is not None
@@ -38,7 +38,7 @@ def test_cli_accepts_multiple_sources(validate_mock):
     sources = ['data1.csv', 'data2.csv']
     expected_sources = [{'source': source} for source in sources]
 
-    CliRunner().invoke(goodtables.cli.cli, sources)
+    CliRunner().invoke(cli, sources)
 
     last_call_args = validate_mock.call_args
     assert last_call_args is not None
@@ -48,7 +48,7 @@ def test_cli_accepts_multiple_sources(validate_mock):
 def test_cli_init():
     resource_path = 'data/valid.csv'
 
-    result = CliRunner().invoke(goodtables.cli.init, [resource_path])
+    result = CliRunner().invoke(init, [resource_path])
 
     assert result.exit_code
 
@@ -63,7 +63,7 @@ def test_cli_adds_schema_to_nested_sources(validate_mock):
     sources = ['data1.csv', 'data2.csv']
     schema = 'schema.json'
 
-    CliRunner().invoke(goodtables.cli.cli, sources + ['--schema', schema])
+    CliRunner().invoke(cli, sources + ['--schema', schema])
 
     last_call_args = validate_mock.call_args
     sources = last_call_args[0][0]


### PR DESCRIPTION
# Overview

We rebase on pydoc-markdown which is really close to the almost standard Google docstrings syntax
