### PR TITLE
Unique constraint: don't rely on enumerate for row number

### DIFF
--- a/goodtables/checks/unique_constraint.py
+++ b/goodtables/checks/unique_constraint.py
@@ -64,8 +64,9 @@ def _create_unique_fields_cache(cells):
     cache = {}
 
     # Unique
-    for column_number, cell in enumerate(cells, start=1):
+    for _, cell in enumerate(cells, start=1):
         field = cell.get('field')
+        column_number = cell.get('column-number')
         if field is not None:
             if field.descriptor.get('primaryKey'):
                 primary_key_column_numbers.append(column_number)

--- a/goodtables/checks/unique_constraint.py
+++ b/goodtables/checks/unique_constraint.py
@@ -29,8 +29,8 @@ class UniqueConstraint(object):
         for column_numbers, cache in self.__unique_fields_cache.items():
             column_cells = tuple(
                 cell
-                for column_number, cell in enumerate(cells, start=1)
-                if column_number in column_numbers
+                for _, cell in enumerate(cells, start=1)
+                if cell["column-number"] in column_numbers
             )
             column_values = tuple(cell.get('value') for cell in column_cells)
             row_number = column_cells[0]['row-number']


### PR DESCRIPTION
Fixes #332 

The column number coming from enumerate was the wrong one when a cell was deleted by a previous failing check, hence applying the unique constraint to a wrong column. Getting the column number from the cell directly fixes the thing.

---
Please preserve this line to notify @roll (lead of this repository)
