### PR TITLE
Improved 'foreign-key' error with column-number, if not composite

### DIFF
--- a/goodtables/contrib/checks/foreign_key.py
+++ b/goodtables/contrib/checks/foreign_key.py
@@ -68,8 +68,19 @@ class ForeignKey(object):
             if success is None:
                 message = 'Foreign key "{fields}" violation in row {row_number}'
                 message_substitutions = {'fields': foreign_key['fields']}
+
+                # if not a composite foreign-key, add the cell causing the violation to improve the error details with the column-number
+                # one-liner -> error_cell = next((cell for cell in cells if cell['header'] == foreign_key['fields'][0]), None) if len(foreign_key['fields']) == 1 else None
+                error_cell = None
+                if len(foreign_key['fields']) == 1:
+                    for cell in cells:
+                        if cell['header'] == foreign_key['fields'][0]:
+                            error_cell = cell
+                            break
+
                 errors.append(Error(
                     self.__code,
+                    cell=error_cell,
                     row_number=row_number,
                     message=message,
                     message_substitutions=message_substitutions,


### PR DESCRIPTION
# Overview

Improved 'foreign-key' error, if not caused by a composite foreign key, adding the cell causing the violation to improve the error details with the column-number

---

Please preserve this line to notify @roll (lead of this repository)
