### PR TITLE
A few scenarios do not have unique names (fixes 354)

### DIFF
--- a/tests/scenarios/missing_headers.yml
+++ b/tests/scenarios/missing_headers.yml
@@ -1,4 +1,4 @@
-primary_key_field:
+missing_headers:
   source:
     - [id, last_name, first_name, language]
     - [1, Alex, John, English]
@@ -17,4 +17,6 @@ primary_key_field:
     - structure
   order_fields: true
   report:
-    - [1, null, 5, 'missing-header']
+    - [1, null, null, 'missing-header']
+    - [1, null, 4, 'non-matching-header']
+    - [1, null, 5, 'extra-header']

--- a/tests/scenarios/multipart.yml
+++ b/tests/scenarios/multipart.yml
@@ -1,4 +1,4 @@
-datapackages:
+multipart:
   source: data/datapackages/multipart/datapackage.json
   preset: datapackage
   report:

--- a/tests/scenarios/primary_key_fields.yml
+++ b/tests/scenarios/primary_key_fields.yml
@@ -1,4 +1,4 @@
-primary_key_field:
+primary_key_fields:
   source:
     - [id, name]
     - [1, Alex']

--- a/tests/scenarios/reordered_headers_with_missing_header_and_extra_header.yml
+++ b/tests/scenarios/reordered_headers_with_missing_header_and_extra_header.yml
@@ -1,4 +1,4 @@
-primary_key_field:
+reordered_headers_with_missing_header_and_extra_header:
   source:
     - [LastName, FirstName, Address]
     - [Test, Tester, 23 Avenue]


### PR DESCRIPTION
@roll, this fixes #354 by updating the scenario names to match the YAML file names as you did with the other scenarios.

I also noticed that missing_headers.yml expected only one of the three errors present in the data and schema. I updated it to expect all three errors.

Here is the test log showing that these scenarios are now executed:

```
% py.test -vv tests/test_scenarios.py
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /Users/david/dev/goodtables-py/venv37/bin/python3
cachedir: .pytest_cache
rootdir: /Users/david/dev/goodtables, inifile: pytest.ini
plugins: pylama-7.7.1, cov-2.8.1
collected 46 items                                                                                                                                           

tests/test_scenarios.py::test_scenarios[datapackages-scenario0] PASSED                                                                                 [  2%]
tests/test_scenarios.py::test_scenarios[defective_rows-scenario1] PASSED                                                                               [  4%]
tests/test_scenarios.py::test_scenarios[duplicate_columns-scenario2] PASSED                                                                            [  6%]
tests/test_scenarios.py::test_scenarios[duplicate_rows-scenario3] PASSED                                                                               [  8%]
tests/test_scenarios.py::test_scenarios[empty_rows-scenario4] PASSED                                                                                   [ 10%]
tests/test_scenarios.py::test_scenarios[empty_rows_multiple-scenario5] PASSED                                                                          [ 13%]
tests/test_scenarios.py::test_scenarios[fail_fast_two_schema_errors-scenario6] PASSED                                                                  [ 15%]
tests/test_scenarios.py::test_scenarios[fail_fast_two_structure_errors-scenario7] PASSED                                                               [ 17%]
tests/test_scenarios.py::test_scenarios[gla-250-report-2013-14-P07-scenario8] PASSED                                                                   [ 19%]
tests/test_scenarios.py::test_scenarios[gla-250-report-2014-15-P07-scenario9] PASSED                                                                   [ 21%]
tests/test_scenarios.py::test_scenarios[gla-250-report-2014-15-P08-scenario10] PASSED                                                                  [ 23%]
tests/test_scenarios.py::test_scenarios[headerless_columns-scenario11] PASSED                                                                          [ 26%]
tests/test_scenarios.py::test_scenarios[missing_headers-scenario12] PASSED                                                                             [ 28%]
tests/test_scenarios.py::test_scenarios[multilingual-scenario13] PASSED                                                                                [ 30%]
tests/test_scenarios.py::test_scenarios[multipart-scenario14] PASSED                                                                                   [ 32%]
tests/test_scenarios.py::test_scenarios[primary_key_field-scenario15] PASSED                                                                           [ 34%]
tests/test_scenarios.py::test_scenarios[primary_key_fields-scenario16] PASSED                                                                          [ 36%]
tests/test_scenarios.py::test_scenarios[reordered_headers_with_missing_header_and_extra_header-scenario17] PASSED                                      [ 39%]
tests/test_scenarios.py::test_scenarios[required_false-scenario18] PASSED                                                                              [ 41%]
tests/test_scenarios.py::test_scenarios[row_limit_schema-scenario19] PASSED                                                                            [ 43%]
tests/test_scenarios.py::test_scenarios[row_limit_structure-scenario20] PASSED                                                                         [ 45%]
tests/test_scenarios.py::test_scenarios[unique_field-scenario21] PASSED                                                                                [ 47%]
tests/test_scenarios.py::test_scenarios[unique_field_wrong_type_or_format-scenario22] PASSED                                                           [ 50%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[datapackages-scenario0] PASSED                                                            [ 52%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[defective_rows-scenario1] PASSED                                                          [ 54%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[duplicate_columns-scenario2] PASSED                                                       [ 56%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[duplicate_rows-scenario3] PASSED                                                          [ 58%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[empty_rows-scenario4] PASSED                                                              [ 60%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[empty_rows_multiple-scenario5] PASSED                                                     [ 63%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[fail_fast_two_schema_errors-scenario6] PASSED                                             [ 65%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[fail_fast_two_structure_errors-scenario7] PASSED                                          [ 67%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[gla-250-report-2013-14-P07-scenario8] PASSED                                              [ 69%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[gla-250-report-2014-15-P07-scenario9] PASSED                                              [ 71%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[gla-250-report-2014-15-P08-scenario10] PASSED                                             [ 73%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[headerless_columns-scenario11] PASSED                                                     [ 76%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[missing_headers-scenario12] PASSED                                                        [ 78%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[multilingual-scenario13] PASSED                                                           [ 80%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[multipart-scenario14] PASSED                                                              [ 82%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[primary_key_field-scenario15] PASSED                                                      [ 84%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[primary_key_fields-scenario16] PASSED                                                     [ 86%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[reordered_headers_with_missing_header_and_extra_header-scenario17] PASSED                 [ 89%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[required_false-scenario18] PASSED                                                         [ 91%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[row_limit_schema-scenario19] PASSED                                                       [ 93%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[row_limit_structure-scenario20] PASSED                                                    [ 95%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[unique_field-scenario21] PASSED                                                           [ 97%]
tests/test_scenarios.py::test_scenarios_return_valid_reports[unique_field_wrong_type_or_format-scenario22] PASSED                                      [100%]
```
---

Please preserve this line to notify @roll (lead of this repository)
